### PR TITLE
fix: resolve icon mismatch in recycled list views #53

### DIFF
--- a/lib/screens/updates_screen.dart
+++ b/lib/screens/updates_screen.dart
@@ -359,6 +359,7 @@ class _UpdatesScreenState extends State<UpdatesScreen>
 
                 return Card(
                   elevation: 0,
+                  key: Key(app.packageName),
                   child: Column(
                     children: [
                       AppListItem(
@@ -469,6 +470,7 @@ class _UpdatesScreenState extends State<UpdatesScreen>
           (updateApp) => updateApp.packageName == app.packageName,
         );
         return Card(
+          key: Key(app.packageName),
           elevation: 0,
           child: Column(
             children: [

--- a/lib/screens/user_screen.dart
+++ b/lib/screens/user_screen.dart
@@ -184,6 +184,7 @@ class _UserScreenState extends State<UserScreen>
         );
         return Card(
           elevation: 0,
+          key: Key(app.packageName),
           child: Column(
             children: [
               AppListItem(


### PR DESCRIPTION
# Description
Fixed an issue where app icons in the "On Device" tab would get mismatched after uninstalling an app and scrolling. This was caused by Flutter's widget recycling in `ListView.builder` reusing the state of `AppListItem` incorrectly when list items were shifted or removed.

# Key Changes
- Added `key: Key(app.packageName)` to the root `Card` widget in `UpdatesScreen` (Updates and On Device tabs) and `UserScreen` (Favorites tab).
- By providing a unique key based on the package name, Flutter's diffing engine can correctly identify when a widget at a specific index has changed to a different app, forcing a fresh state creation instead of reusing an incompatible one.

# Impact
- **UI Consistency**: App icons now correctly stay attached to their respective app listings during dynamic updates like uninstalls.
- **Improved Reliability**: Resolves the "offset by one" visual bug reported in Issue #53.

Fixes: https://github.com/Nandanrmenon/florid/issues/53