### PR TITLE
Add Japanese (ja) localization

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -387,5 +387,64 @@
       "appCount": {}
     }
   },
-  "ignore_future_updates": "Ignore Future Updates"
+  "ignore_future_updates": "Ignore Future Updates",
+  "general_settings": "General Settings",
+  "view_favourite_apps_subtitle": "View your favourite apps",
+  "appearance_subtitle": "Theme mode and style",
+  "parental_control": "Parental Control",
+  "parental_control_subtitle": "Hide anti-feature apps and protect installs",
+  "app_content_language": "App content language",
+  "repositories_and_management": "Repositories & Management",
+  "manage_repositories_subtitle": "Add or remove F-Droid repositories",
+  "app_management_subtitle": "Manage settings regarding installs and updates",
+  "miscellaneous": "Miscellaneous",
+  "troubleshooting_subtitle": "Storage, cache, and downloads",
+  "florid_tagline": "A modern F-Droid client.",
+  "source_code_subtitle": "View the Florid source code on GitHub",
+  "telegram": "Telegram",
+  "telegram_subtitle": "Join the community on Telegram",
+  "matrix": "Matrix",
+  "matrix_subtitle": "Join the community on Matrix",
+  "report_an_issue": "Report an issue",
+  "report_an_issue_subtitle": "Found a bug? Let us know!",
+  "donate": "Donate",
+  "donate_subtitle": "Support continued development of Florid",
+  "share_florid": "Share Florid",
+  "share_florid_subtitle": "Let your nerdy friends know about Florid!",
+  "share_florid_title": "Check out Florid!",
+  "share_florid_message": "A modern F-Droid client! https://github.com/Nandanrmenon/florid",
+  "select_language": "Select Language",
+  "language_changed_to": "Language changed to {language}.",
+  "@language_changed_to": {
+    "placeholders": {
+      "language": {}
+    }
+  },
+  "export_favourites": "Export favourites",
+  "no_favourites_to_export": "No favourites to export",
+  "unable_to_access_downloads": "Unable to access Downloads folder",
+  "saved_to_downloads": "Saved to Downloads: {path}",
+  "@saved_to_downloads": {
+    "placeholders": {
+      "path": {}
+    }
+  },
+  "no_favourites_to_import": "No favourites found to import",
+  "favourites_import_found": "Found {count} {count, plural, =1{favourite} other{favourites}} in {fileName}.",
+  "@favourites_import_found": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "fileName": {}
+    }
+  },
+  "favourites_imported": "Imported {count} {count, plural, =1{favourite} other{favourites}}",
+  "@favourites_imported": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -385,5 +385,64 @@
       "appCount": {}
     }
   },
-  "ignore_future_updates": "今後の更新を無視"
+  "ignore_future_updates": "今後の更新を無視",
+  "general_settings": "一般設定",
+  "view_favourite_apps_subtitle": "お気に入りアプリを表示",
+  "appearance_subtitle": "テーマモードとスタイル",
+  "parental_control": "ペアレンタルコントロール",
+  "parental_control_subtitle": "アンチ機能アプリの非表示とインストール保護",
+  "app_content_language": "アプリ表示言語",
+  "repositories_and_management": "リポジトリと管理",
+  "manage_repositories_subtitle": "F-Droid リポジトリの追加・削除",
+  "app_management_subtitle": "インストールと更新に関する設定",
+  "miscellaneous": "その他",
+  "troubleshooting_subtitle": "ストレージ、キャッシュ、ダウンロード",
+  "florid_tagline": "モダンな F-Droid クライアント。",
+  "source_code_subtitle": "GitHub で Florid のソースコードを表示",
+  "telegram": "Telegram",
+  "telegram_subtitle": "Telegram コミュニティに参加",
+  "matrix": "Matrix",
+  "matrix_subtitle": "Matrix コミュニティに参加",
+  "report_an_issue": "問題を報告",
+  "report_an_issue_subtitle": "バグを見つけましたか？お知らせください！",
+  "donate": "寄付",
+  "donate_subtitle": "Florid の開発を支援",
+  "share_florid": "Florid を共有",
+  "share_florid_subtitle": "詳しい友達に Florid を教えましょう！",
+  "share_florid_title": "Florid をチェック！",
+  "share_florid_message": "モダンな F-Droid クライアント！ https://github.com/Nandanrmenon/florid",
+  "select_language": "言語を選択",
+  "language_changed_to": "言語を {language} に変更しました。",
+  "@language_changed_to": {
+    "placeholders": {
+      "language": {}
+    }
+  },
+  "export_favourites": "お気に入りをエクスポート",
+  "no_favourites_to_export": "エクスポートするお気に入りがありません",
+  "unable_to_access_downloads": "ダウンロードフォルダにアクセスできません",
+  "saved_to_downloads": "ダウンロードに保存しました: {path}",
+  "@saved_to_downloads": {
+    "placeholders": {
+      "path": {}
+    }
+  },
+  "no_favourites_to_import": "インポートするお気に入りが見つかりません",
+  "favourites_import_found": "{fileName} に {count} 件のお気に入りが見つかりました。",
+  "@favourites_import_found": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "fileName": {}
+    }
+  },
+  "favourites_imported": "{count} 件のお気に入りをインポートしました",
+  "@favourites_imported": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,0 +1,389 @@
+{
+  "@@locale": "ja",
+  "app_name": "Florid",
+  "welcome": "Florid へようこそ",
+  "search": "検索",
+  "settings": "設定",
+  "home": "ホーム",
+  "categories": "カテゴリ",
+  "updates": "更新",
+  "installed": "インストール済み",
+  "download": "ダウンロード",
+  "install": "インストール",
+  "uninstall": "アンインストール",
+  "open": "開く",
+  "cancel": "キャンセル",
+  "update_available": "更新あり",
+  "downloading": "ダウンロード中...",
+  "install_permission_required": "インストール権限が必要です",
+  "storage_permission_required": "ストレージ権限が必要です",
+  "cancel_download": "ダウンロードをキャンセル",
+  "version": "バージョン",
+  "size": "サイズ",
+  "description": "説明",
+  "permissions": "権限",
+  "screenshots": "スクリーンショット",
+  "no_version_available": "利用可能なバージョンがありません",
+  "app_information": "アプリ情報",
+  "package_name": "パッケージ名",
+  "license": "ライセンス",
+  "added": "追加日",
+  "last_updated": "最終更新",
+  "version_information": "バージョン情報",
+  "version_name": "バージョン名",
+  "version_code": "バージョンコード",
+  "min_sdk": "最小 SDK",
+  "target_sdk": "ターゲット SDK",
+  "all_versions": "すべてのバージョン",
+  "latest": "最新",
+  "released": "リリース日",
+  "loading": "読み込み中...",
+  "error": "エラー",
+  "retry": "再試行",
+  "share": "共有",
+  "website": "ウェブサイト",
+  "source_code": "ソースコード",
+  "issue_tracker": "課題トラッカー",
+  "whats_new": "新機能",
+  "show_more": "もっと見る",
+  "show_less": "閉じる",
+  "downloads_stats": "ダウンロード統計",
+  "last_day": "過去 1 日",
+  "last_30_days": "過去 30 日",
+  "last_365_days": "過去 365 日",
+  "not_available": "利用不可",
+  "download_failed": "ダウンロードに失敗しました",
+  "installation_failed": "インストールに失敗しました",
+  "uninstall_failed": "アンインストールに失敗しました",
+  "open_failed": "開けませんでした",
+  "device": "デバイス",
+  "recently_updated": "最近の更新",
+  "refresh": "更新",
+  "about": "このアプリについて",
+  "refreshing_data": "データを更新中...",
+  "data_refreshed": "データを更新しました",
+  "refresh_failed": "更新に失敗しました",
+  "loading_latest_apps": "最新アプリを読み込み中...",
+  "latest_apps": "最新アプリ",
+  "no_apps_found": "アプリが見つかりません",
+  "searching": "検索中...",
+  "setup_failed": "セットアップに失敗しました",
+  "back": "戻る",
+  "allow": "許可",
+  "manage_repositories": "リポジトリを管理",
+  "enable_disable": "有効/無効",
+  "edit": "編集",
+  "delete": "削除",
+  "delete_repository": "リポジトリを削除",
+  "delete_repository_confirm": "「{name}」を削除してもよろしいですか？",
+  "@delete_repository_confirm": {
+    "description": "Confirmation message for deleting a repository. {name} is the repository name.",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "updating_repository": "リポジトリを更新中",
+  "touch_grass_message": "外の空気を吸うのにぴったりの時間です！",
+  "add_repository": "リポジトリを追加",
+  "add": "追加",
+  "save": "保存",
+  "enter_repository_name": "リポジトリ名を入力してください",
+  "enter_repository_url": "リポジトリ URL を入力してください",
+  "edit_repository": "リポジトリを編集",
+  "loading_apps": "アプリを読み込み中...",
+  "no_apps_in_category": "{category} にアプリが見つかりません",
+  "@no_apps_in_category": {
+    "description": "Message shown when no apps are found in a category. {category} is the category name.",
+    "placeholders": {
+      "category": {}
+    }
+  },
+  "loading_categories": "カテゴリを読み込み中...",
+  "no_categories_found": "カテゴリが見つかりません",
+  "on_device": "デバイス上",
+  "favourites": "お気に入り",
+  "loading_repository": "リポジトリを読み込み中…",
+  "unable_to_load_repository": "リポジトリを読み込めません",
+  "repository_loading_error_descrption": "接続またはリポジトリ設定を確認して、もう一度お試しください。",
+  "appUpdateAvailable": "更新あり",
+  "releaseNotes": "リリースノート",
+  "dismiss": "閉じる",
+  "viewOnGithub": "GitHub で表示",
+  "update": "更新",
+  "installing": "インストール中...",
+  "downloadFailed": "APK のダウンロードに失敗しました",
+  "remove_from_favourites": "お気に入りから削除",
+  "add_to_favourites": "お気に入りに追加",
+  "view_details": "詳細を表示",
+  "installation_started": "{appName} のインストールを開始しました！",
+  "@installation_started": {
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "installation_failed_with_error": "インストールに失敗しました: {error}",
+  "@installation_failed_with_error": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "download_started": "{appName} のダウンロードを開始しました！",
+  "@download_started": {
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "download_failed_with_error": "ダウンロードに失敗しました: {error}",
+  "@download_failed_with_error": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "start_setup": "セットアップを開始",
+  "continue_text": "続ける",
+  "loading_changelog": "変更履歴を読み込み中...",
+  "appearance": "外観",
+  "theme_mode": "テーマモード",
+  "follow_system_theme": "システム設定に従う",
+  "light_theme": "ライトテーマ",
+  "dark_theme": "ダークテーマ",
+  "dynamic_color": "ダイナミックカラー",
+  "material_you_dynamic": "Material You Dynamic",
+  "use_system_colors_supported_android": "対応する Android デバイスでシステムカラーを使用",
+  "theme_style": "テーマスタイル",
+  "material_style": "Material スタイル",
+  "dark_knight": "Dark Knight",
+  "dark_knight_subtitle": "ダークで高コントラストな Florid 風テーマ",
+  "florid_style": "Florid スタイル",
+  "beta": "ベータ",
+  "other": "その他",
+  "show_whats_new": "新機能を表示",
+  "show_monthly_top_apps": "月間トップアプリを表示",
+  "feedback_on_florid_theme": "Florid テーマへのフィードバック",
+  "help_improve_florid_theme_feedback": "フィードバックで Florid テーマの改善にご協力ください",
+  "system_installer": "システムインストーラー",
+  "shizuku": "Shizuku",
+  "installation_method": "インストール方法",
+  "requires_shizuku_running": "Shizuku の起動が必要です",
+  "uses_standard_system_installer": "標準のシステムインストーラーを使用します",
+  "open_shizuku": "Shizuku を開く",
+  "use_system_installer": "システムインストーラーを使用",
+  "close": "閉じる",
+  "wifi_only": "Wi-Fi のみ",
+  "wifi_and_charging": "Wi-Fi + 充電中",
+  "mobile_data_or_wifi": "モバイルデータまたは Wi-Fi",
+  "every_1_hour": "1 時間ごと",
+  "every_2_hours": "2 時間ごと",
+  "every_3_hours": "3 時間ごと",
+  "every_6_hours": "6 時間ごと",
+  "every_12_hours": "12 時間ごと",
+  "daily": "毎日",
+  "every_hours": "{hours} 時間ごと",
+  "@every_hours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "update_network": "更新時のネットワーク",
+  "update_interval": "更新間隔",
+  "app_management": "アプリ管理",
+  "alpha": "アルファ",
+  "privacy": "プライバシー",
+  "opt_out_of_telemetry": "テレメトリをオプトアウト",
+  "opt_out_of_telemetry_subtitle": "アクティブユーザー数（匿名）の把握に役立ちます",
+  "downloads_and_storage": "ダウンロードとストレージ",
+  "auto_install_after_download": "ダウンロード後に自動インストール",
+  "auto_install_after_download_subtitle": "ダウンロード完了後に APK を自動的にインストール",
+  "delete_apk_after_install": "インストール後に APK を削除",
+  "delete_apk_after_install_subtitle": "インストール成功後にインストーラーファイルを削除",
+  "background_updates": "バックグラウンド更新",
+  "check_updates_in_background": "バックグラウンドで更新を確認",
+  "notify_when_updates_available": "更新があるときに通知",
+  "reliability": "信頼性",
+  "disable_battery_optimization": "バッテリー最適化を無効化",
+  "allow_background_checks_reliably": "バックグラウンドチェックを確実に実行",
+  "run_debug_check_10s": "10 秒後にデバッグチェックを実行",
+  "run_debug_check_10s_subtitle": "テスト通知を表示し、10 秒後に実行します",
+  "debug_check_scheduled": "デバッグチェックをスケジュールしました",
+  "debug_update_check_runs_10s": "デバッグ更新チェックは 10 秒後に実行されます",
+  "no_recently_updated_apps": "最近更新されたアプリはありません",
+  "no_new_apps": "新しいアプリはありません",
+  "monthly_top_apps": "月間トップアプリ",
+  "from_izzyondroid": "IzzyOnDroid より",
+  "sync_required": "同期が必要です",
+  "izzyondroid_sync_required_message": "トップアプリを表示するには IzzyOnDroid リポジトリの同期が必要です。",
+  "go_to_settings": "設定へ",
+  "keep_android_open": "Android をオープンに",
+  "keep_android_open_message": "2026/2027 年以降、Google は Play ストア以外からインストールしたアプリを含め、認証済みデバイス上のすべての Android アプリに開発者認証を義務付けます。",
+  "ignore": "無視",
+  "learn_more": "詳細を見る",
+  "search_fdroid_apps": "F-Droid アプリを検索...",
+  "filters": "フィルター",
+  "search_apps": "アプリを検索",
+  "search_failed": "検索に失敗しました",
+  "unknown_error_occurred": "不明なエラーが発生しました",
+  "try_different_keywords": "別のキーワードを試すか、スペルを確認してください",
+  "popular_searches": "人気の検索:",
+  "clear_all": "すべてクリア",
+  "sort_by": "並べ替え",
+  "relevance": "関連度",
+  "name_az": "名前 (A-Z)",
+  "name_za": "名前 (Z-A)",
+  "recently_added": "最近追加",
+  "no_categories_available": "利用可能なカテゴリがありません",
+  "repositories": "リポジトリ",
+  "apply_filters": "フィルターを適用",
+  "search_results_for_query": "「{query}」の検索結果 {count} 件",
+  "@search_results_for_query": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "query": {}
+    }
+  },
+  "loading_top_apps": "トップアプリを読み込み中...",
+  "failed_to_load_apps": "アプリの読み込みに失敗しました",
+  "try_again": "再試行",
+  "no_apps_from_izzyondroid": "IzzyOnDroid からのアプリはありません",
+  "no_favourites_yet": "お気に入りはまだありません",
+  "tap_star_to_save": "アプリの星をタップしてここに保存",
+  "update_failed_with_error": "更新に失敗しました: {error}",
+  "@update_failed_with_error": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "user": "ユーザー",
+  "auto_install_failed_with_error": "自動インストールに失敗しました: {error}",
+  "@auto_install_failed_with_error": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "installing_app": "{appName} をインストール中...",
+  "@installing_app": {
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "install_from_repository": "リポジトリからインストール",
+  "download_from_repository": "リポジトリからダウンロード",
+  "choose_repository_for_action": "このアプリを{action}するリポジトリを選択できます。",
+  "@choose_repository_for_action": {
+    "placeholders": {
+      "action": {}
+    }
+  },
+  "unknown": "不明",
+  "previously_installed_from": "以前のインストール元: {repositoryName}",
+  "@previously_installed_from": {
+    "placeholders": {
+      "repositoryName": {}
+    }
+  },
+  "previously_installed_from_here": "以前ここからインストール済み",
+  "default_repository": "デフォルト",
+  "by_author": "作者: {author}",
+  "@by_author": {
+    "placeholders": {
+      "author": {}
+    }
+  },
+  "check_out_on_fdroid": "F-Droid で {appName} をチェック: https://f-droid.org/packages/{packageName}/",
+  "@check_out_on_fdroid": {
+    "placeholders": {
+      "appName": {},
+      "packageName": {}
+    }
+  },
+  "rebuild_repositories": "リポジトリを再構築",
+  "preset": "プリセット",
+  "your_repositories": "あなたのリポジトリ",
+  "no_custom_repositories": "カスタムリポジトリは追加されていません",
+  "add_custom_repository_to_start": "カスタム F-Droid リポジトリを追加して始めましょう",
+  "scan": "スキャン",
+  "point_camera_qr": "カメラを QR コードに向けてください",
+  "tap_keyboard_enter_url": "キーボードをタップして URL を手動入力",
+  "loading_repository_configuration": "リポジトリ設定を読み込み中...",
+  "adding_selected_repositories": "選択したリポジトリを追加中...",
+  "fetching_fdroid_repository_index": "F-Droid リポジトリインデックスを取得中...",
+  "importing_apps_to_database": "アプリをデータベースにインポート中...",
+  "importing_apps_to_database_seconds": "アプリをデータベースにインポート中... ({seconds}秒)",
+  "@importing_apps_to_database_seconds": {
+    "placeholders": {
+      "seconds": {
+        "type": "int"
+      }
+    }
+  },
+  "loading_custom_repositories": "カスタムリポジトリを読み込み中...",
+  "setup_complete": "セットアップ完了！",
+  "welcome_to": "ようこそ",
+  "onboarding_intro_subtitle": "オープンソース Android アプリを簡単に閲覧・検索・ダウンロードできるモダンな F-Droid クライアントです。",
+  "curated_open_source_apps": "厳選されたオープンソースアプリ",
+  "safe_downloads": "安全なダウンロード",
+  "updates_and_notifications": "更新と通知",
+  "add_extra_repositories": "追加リポジトリを登録",
+  "repos_step_description": "Florid には公式 F-Droid リポジトリが同梱されています。信頼できるコミュニティリポジトリを追加して、より多くのアプリを入手できます。",
+  "available_repositories": "利用可能なリポジトリ",
+  "manage_repositories_anytime": "設定からいつでもリポジトリを追加・削除できます。",
+  "request_permissions": "権限のリクエスト",
+  "permissions_step_description": "Florid は最高の体験を提供するためにいくつかの権限が必要です。",
+  "notifications": "通知",
+  "get_notified_updates": "アプリが更新されたときに通知を受け取る",
+  "app_installation": "アプリのインストール",
+  "allow_florid_install_apps": "Florid がダウンロードしたアプリをインストールできるようにする",
+  "enable_permissions_anytime": "これらの権限は設定からいつでも有効にできます。",
+  "setting_up_florid": "Florid をセットアップ中",
+  "no_antifeature_listed": "アンチ機能は記載されていません",
+  "open_link": "リンクを開く",
+  "loading_recently_updated_apps": "最近更新されたアプリを読み込み中...",
+  "checking_for_updates": "更新を確認中",
+  "import_favourites": "お気に入りをインポート",
+  "merge": "マージ",
+  "update_all": "すべて更新",
+  "apps": "アプリ",
+  "troubleshooting": "トラブルシューティング",
+  "replace": "置き換え",
+  "your_name": "お名前",
+  "enter_your_name": "お名前を入力",
+  "top_apps": "トップアプリ",
+  "games": "ゲーム",
+  "auth_all_apps": "すべてのアプリ",
+  "auth_all_apps_desc": "すべてのインストールに認証を要求",
+  "auth_all_apps_w_anti_feat": "アンチ機能のあるアプリ",
+  "auth_all_apps_w_anti_feat_desc": "アンチ機能のあるアプリのインストール時のみ認証を要求します。",
+  "support_the_developer": "開発者を支援",
+  "available_on_repository": "利用可能: {repositoryName}",
+  "@available_on_repository": {
+    "description": "Label showing the primary repository name for an app.",
+    "placeholders": {
+      "repositoryName": {}
+    }
+  },
+  "also_available_from_repositories": "他のリポジトリでも利用可能: {repositoryNames}",
+  "@also_available_from_repositories": {
+    "description": "Label listing additional repository names where the app is available.",
+    "placeholders": {
+      "repositoryNames": {}
+    }
+  },
+  "onboarding_setup_type": "セットアップタイプ",
+  "onboarding_setup_type_desc": "Florid のセットアップ方法を選択",
+  "onboarding_setup_basic": "基本セットアップ",
+  "onboarding_setup_basic_desc": "推奨リポジトリでクイックスタート",
+  "onboarding_setup_advanced": "詳細セットアップ",
+  "onboarding_setup_advanced_desc": "リポジトリと設定をカスタマイズ",
+  "help_us_improve_florid": "Florid の改善にご協力ください",
+  "section_app_count": "{appCount} 件のアプリ",
+  "@section_app_count": {
+    "description": "Label showing the number of apps in a category",
+    "placeholders": {
+      "appCount": {}
+    }
+  },
+  "ignore_future_updates": "今後の更新を無視"
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1776,6 +1776,210 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Ignore Future Updates'**
   String get ignore_future_updates;
+
+  /// No description provided for @general_settings.
+  ///
+  /// In en, this message translates to:
+  /// **'General Settings'**
+  String get general_settings;
+
+  /// No description provided for @view_favourite_apps_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'View your favourite apps'**
+  String get view_favourite_apps_subtitle;
+
+  /// No description provided for @appearance_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Theme mode and style'**
+  String get appearance_subtitle;
+
+  /// No description provided for @parental_control.
+  ///
+  /// In en, this message translates to:
+  /// **'Parental Control'**
+  String get parental_control;
+
+  /// No description provided for @parental_control_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide anti-feature apps and protect installs'**
+  String get parental_control_subtitle;
+
+  /// No description provided for @app_content_language.
+  ///
+  /// In en, this message translates to:
+  /// **'App content language'**
+  String get app_content_language;
+
+  /// No description provided for @repositories_and_management.
+  ///
+  /// In en, this message translates to:
+  /// **'Repositories & Management'**
+  String get repositories_and_management;
+
+  /// No description provided for @manage_repositories_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add or remove F-Droid repositories'**
+  String get manage_repositories_subtitle;
+
+  /// No description provided for @app_management_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Manage settings regarding installs and updates'**
+  String get app_management_subtitle;
+
+  /// No description provided for @miscellaneous.
+  ///
+  /// In en, this message translates to:
+  /// **'Miscellaneous'**
+  String get miscellaneous;
+
+  /// No description provided for @troubleshooting_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Storage, cache, and downloads'**
+  String get troubleshooting_subtitle;
+
+  /// No description provided for @florid_tagline.
+  ///
+  /// In en, this message translates to:
+  /// **'A modern F-Droid client.'**
+  String get florid_tagline;
+
+  /// No description provided for @source_code_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'View the Florid source code on GitHub'**
+  String get source_code_subtitle;
+
+  /// No description provided for @telegram.
+  ///
+  /// In en, this message translates to:
+  /// **'Telegram'**
+  String get telegram;
+
+  /// No description provided for @telegram_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Join the community on Telegram'**
+  String get telegram_subtitle;
+
+  /// No description provided for @matrix.
+  ///
+  /// In en, this message translates to:
+  /// **'Matrix'**
+  String get matrix;
+
+  /// No description provided for @matrix_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Join the community on Matrix'**
+  String get matrix_subtitle;
+
+  /// No description provided for @report_an_issue.
+  ///
+  /// In en, this message translates to:
+  /// **'Report an issue'**
+  String get report_an_issue;
+
+  /// No description provided for @report_an_issue_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Found a bug? Let us know!'**
+  String get report_an_issue_subtitle;
+
+  /// No description provided for @donate.
+  ///
+  /// In en, this message translates to:
+  /// **'Donate'**
+  String get donate;
+
+  /// No description provided for @donate_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Support continued development of Florid'**
+  String get donate_subtitle;
+
+  /// No description provided for @share_florid.
+  ///
+  /// In en, this message translates to:
+  /// **'Share Florid'**
+  String get share_florid;
+
+  /// No description provided for @share_florid_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Let your nerdy friends know about Florid!'**
+  String get share_florid_subtitle;
+
+  /// No description provided for @share_florid_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Check out Florid!'**
+  String get share_florid_title;
+
+  /// No description provided for @share_florid_message.
+  ///
+  /// In en, this message translates to:
+  /// **'A modern F-Droid client! https://github.com/Nandanrmenon/florid'**
+  String get share_florid_message;
+
+  /// No description provided for @select_language.
+  ///
+  /// In en, this message translates to:
+  /// **'Select Language'**
+  String get select_language;
+
+  /// No description provided for @language_changed_to.
+  ///
+  /// In en, this message translates to:
+  /// **'Language changed to {language}.'**
+  String language_changed_to(Object language);
+
+  /// No description provided for @export_favourites.
+  ///
+  /// In en, this message translates to:
+  /// **'Export favourites'**
+  String get export_favourites;
+
+  /// No description provided for @no_favourites_to_export.
+  ///
+  /// In en, this message translates to:
+  /// **'No favourites to export'**
+  String get no_favourites_to_export;
+
+  /// No description provided for @unable_to_access_downloads.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to access Downloads folder'**
+  String get unable_to_access_downloads;
+
+  /// No description provided for @saved_to_downloads.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved to Downloads: {path}'**
+  String saved_to_downloads(Object path);
+
+  /// No description provided for @no_favourites_to_import.
+  ///
+  /// In en, this message translates to:
+  /// **'No favourites found to import'**
+  String get no_favourites_to_import;
+
+  /// No description provided for @favourites_import_found.
+  ///
+  /// In en, this message translates to:
+  /// **'Found {count} {count, plural, =1{favourite} other{favourites}} in {fileName}.'**
+  String favourites_import_found(int count, Object fileName);
+
+  /// No description provided for @favourites_imported.
+  ///
+  /// In en, this message translates to:
+  /// **'Imported {count} {count, plural, =1{favourite} other{favourites}}'**
+  String favourites_imported(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9,6 +9,7 @@ import 'app_localizations_cs.dart';
 import 'app_localizations_de.dart';
 import 'app_localizations_en.dart';
 import 'app_localizations_it.dart';
+import 'app_localizations_ja.dart';
 import 'app_localizations_tr.dart';
 import 'app_localizations_zh.dart';
 
@@ -102,6 +103,7 @@ abstract class AppLocalizations {
     Locale('de'),
     Locale('en'),
     Locale('it'),
+    Locale('ja'),
     Locale('tr'),
     Locale('zh'),
     Locale('zh', 'CN'),
@@ -1791,6 +1793,7 @@ class _AppLocalizationsDelegate
     'de',
     'en',
     'it',
+    'ja',
     'tr',
     'zh',
   ].contains(locale.languageCode);
@@ -1822,6 +1825,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
       return AppLocalizationsEn();
     case 'it':
       return AppLocalizationsIt();
+    case 'ja':
+      return AppLocalizationsJa();
     case 'tr':
       return AppLocalizationsTr();
     case 'zh':

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -911,4 +911,131 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get ignore_future_updates => 'Ignore Future Updates';
+
+  @override
+  String get general_settings => 'General Settings';
+
+  @override
+  String get view_favourite_apps_subtitle => 'View your favourite apps';
+
+  @override
+  String get appearance_subtitle => 'Theme mode and style';
+
+  @override
+  String get parental_control => 'Parental Control';
+
+  @override
+  String get parental_control_subtitle =>
+      'Hide anti-feature apps and protect installs';
+
+  @override
+  String get app_content_language => 'App content language';
+
+  @override
+  String get repositories_and_management => 'Repositories & Management';
+
+  @override
+  String get manage_repositories_subtitle =>
+      'Add or remove F-Droid repositories';
+
+  @override
+  String get app_management_subtitle =>
+      'Manage settings regarding installs and updates';
+
+  @override
+  String get miscellaneous => 'Miscellaneous';
+
+  @override
+  String get troubleshooting_subtitle => 'Storage, cache, and downloads';
+
+  @override
+  String get florid_tagline => 'A modern F-Droid client.';
+
+  @override
+  String get source_code_subtitle => 'View the Florid source code on GitHub';
+
+  @override
+  String get telegram => 'Telegram';
+
+  @override
+  String get telegram_subtitle => 'Join the community on Telegram';
+
+  @override
+  String get matrix => 'Matrix';
+
+  @override
+  String get matrix_subtitle => 'Join the community on Matrix';
+
+  @override
+  String get report_an_issue => 'Report an issue';
+
+  @override
+  String get report_an_issue_subtitle => 'Found a bug? Let us know!';
+
+  @override
+  String get donate => 'Donate';
+
+  @override
+  String get donate_subtitle => 'Support continued development of Florid';
+
+  @override
+  String get share_florid => 'Share Florid';
+
+  @override
+  String get share_florid_subtitle =>
+      'Let your nerdy friends know about Florid!';
+
+  @override
+  String get share_florid_title => 'Check out Florid!';
+
+  @override
+  String get share_florid_message =>
+      'A modern F-Droid client! https://github.com/Nandanrmenon/florid';
+
+  @override
+  String get select_language => 'Select Language';
+
+  @override
+  String language_changed_to(Object language) {
+    return 'Language changed to $language.';
+  }
+
+  @override
+  String get export_favourites => 'Export favourites';
+
+  @override
+  String get no_favourites_to_export => 'No favourites to export';
+
+  @override
+  String get unable_to_access_downloads => 'Unable to access Downloads folder';
+
+  @override
+  String saved_to_downloads(Object path) {
+    return 'Saved to Downloads: $path';
+  }
+
+  @override
+  String get no_favourites_to_import => 'No favourites found to import';
+
+  @override
+  String favourites_import_found(int count, Object fileName) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Found $count $_temp0 in $fileName.';
+  }
+
+  @override
+  String favourites_imported(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Imported $count $_temp0';
+  }
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -912,4 +912,131 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get ignore_future_updates => 'Ignore Future Updates';
+
+  @override
+  String get general_settings => 'General Settings';
+
+  @override
+  String get view_favourite_apps_subtitle => 'View your favourite apps';
+
+  @override
+  String get appearance_subtitle => 'Theme mode and style';
+
+  @override
+  String get parental_control => 'Parental Control';
+
+  @override
+  String get parental_control_subtitle =>
+      'Hide anti-feature apps and protect installs';
+
+  @override
+  String get app_content_language => 'App content language';
+
+  @override
+  String get repositories_and_management => 'Repositories & Management';
+
+  @override
+  String get manage_repositories_subtitle =>
+      'Add or remove F-Droid repositories';
+
+  @override
+  String get app_management_subtitle =>
+      'Manage settings regarding installs and updates';
+
+  @override
+  String get miscellaneous => 'Miscellaneous';
+
+  @override
+  String get troubleshooting_subtitle => 'Storage, cache, and downloads';
+
+  @override
+  String get florid_tagline => 'A modern F-Droid client.';
+
+  @override
+  String get source_code_subtitle => 'View the Florid source code on GitHub';
+
+  @override
+  String get telegram => 'Telegram';
+
+  @override
+  String get telegram_subtitle => 'Join the community on Telegram';
+
+  @override
+  String get matrix => 'Matrix';
+
+  @override
+  String get matrix_subtitle => 'Join the community on Matrix';
+
+  @override
+  String get report_an_issue => 'Report an issue';
+
+  @override
+  String get report_an_issue_subtitle => 'Found a bug? Let us know!';
+
+  @override
+  String get donate => 'Donate';
+
+  @override
+  String get donate_subtitle => 'Support continued development of Florid';
+
+  @override
+  String get share_florid => 'Share Florid';
+
+  @override
+  String get share_florid_subtitle =>
+      'Let your nerdy friends know about Florid!';
+
+  @override
+  String get share_florid_title => 'Check out Florid!';
+
+  @override
+  String get share_florid_message =>
+      'A modern F-Droid client! https://github.com/Nandanrmenon/florid';
+
+  @override
+  String get select_language => 'Select Language';
+
+  @override
+  String language_changed_to(Object language) {
+    return 'Language changed to $language.';
+  }
+
+  @override
+  String get export_favourites => 'Export favourites';
+
+  @override
+  String get no_favourites_to_export => 'No favourites to export';
+
+  @override
+  String get unable_to_access_downloads => 'Unable to access Downloads folder';
+
+  @override
+  String saved_to_downloads(Object path) {
+    return 'Saved to Downloads: $path';
+  }
+
+  @override
+  String get no_favourites_to_import => 'No favourites found to import';
+
+  @override
+  String favourites_import_found(int count, Object fileName) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Found $count $_temp0 in $fileName.';
+  }
+
+  @override
+  String favourites_imported(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Imported $count $_temp0';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -909,4 +909,131 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get ignore_future_updates => 'Ignore Future Updates';
+
+  @override
+  String get general_settings => 'General Settings';
+
+  @override
+  String get view_favourite_apps_subtitle => 'View your favourite apps';
+
+  @override
+  String get appearance_subtitle => 'Theme mode and style';
+
+  @override
+  String get parental_control => 'Parental Control';
+
+  @override
+  String get parental_control_subtitle =>
+      'Hide anti-feature apps and protect installs';
+
+  @override
+  String get app_content_language => 'App content language';
+
+  @override
+  String get repositories_and_management => 'Repositories & Management';
+
+  @override
+  String get manage_repositories_subtitle =>
+      'Add or remove F-Droid repositories';
+
+  @override
+  String get app_management_subtitle =>
+      'Manage settings regarding installs and updates';
+
+  @override
+  String get miscellaneous => 'Miscellaneous';
+
+  @override
+  String get troubleshooting_subtitle => 'Storage, cache, and downloads';
+
+  @override
+  String get florid_tagline => 'A modern F-Droid client.';
+
+  @override
+  String get source_code_subtitle => 'View the Florid source code on GitHub';
+
+  @override
+  String get telegram => 'Telegram';
+
+  @override
+  String get telegram_subtitle => 'Join the community on Telegram';
+
+  @override
+  String get matrix => 'Matrix';
+
+  @override
+  String get matrix_subtitle => 'Join the community on Matrix';
+
+  @override
+  String get report_an_issue => 'Report an issue';
+
+  @override
+  String get report_an_issue_subtitle => 'Found a bug? Let us know!';
+
+  @override
+  String get donate => 'Donate';
+
+  @override
+  String get donate_subtitle => 'Support continued development of Florid';
+
+  @override
+  String get share_florid => 'Share Florid';
+
+  @override
+  String get share_florid_subtitle =>
+      'Let your nerdy friends know about Florid!';
+
+  @override
+  String get share_florid_title => 'Check out Florid!';
+
+  @override
+  String get share_florid_message =>
+      'A modern F-Droid client! https://github.com/Nandanrmenon/florid';
+
+  @override
+  String get select_language => 'Select Language';
+
+  @override
+  String language_changed_to(Object language) {
+    return 'Language changed to $language.';
+  }
+
+  @override
+  String get export_favourites => 'Export favourites';
+
+  @override
+  String get no_favourites_to_export => 'No favourites to export';
+
+  @override
+  String get unable_to_access_downloads => 'Unable to access Downloads folder';
+
+  @override
+  String saved_to_downloads(Object path) {
+    return 'Saved to Downloads: $path';
+  }
+
+  @override
+  String get no_favourites_to_import => 'No favourites found to import';
+
+  @override
+  String favourites_import_found(int count, Object fileName) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Found $count $_temp0 in $fileName.';
+  }
+
+  @override
+  String favourites_imported(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Imported $count $_temp0';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -926,4 +926,131 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get ignore_future_updates => 'Ignore Future Updates';
+
+  @override
+  String get general_settings => 'General Settings';
+
+  @override
+  String get view_favourite_apps_subtitle => 'View your favourite apps';
+
+  @override
+  String get appearance_subtitle => 'Theme mode and style';
+
+  @override
+  String get parental_control => 'Parental Control';
+
+  @override
+  String get parental_control_subtitle =>
+      'Hide anti-feature apps and protect installs';
+
+  @override
+  String get app_content_language => 'App content language';
+
+  @override
+  String get repositories_and_management => 'Repositories & Management';
+
+  @override
+  String get manage_repositories_subtitle =>
+      'Add or remove F-Droid repositories';
+
+  @override
+  String get app_management_subtitle =>
+      'Manage settings regarding installs and updates';
+
+  @override
+  String get miscellaneous => 'Miscellaneous';
+
+  @override
+  String get troubleshooting_subtitle => 'Storage, cache, and downloads';
+
+  @override
+  String get florid_tagline => 'A modern F-Droid client.';
+
+  @override
+  String get source_code_subtitle => 'View the Florid source code on GitHub';
+
+  @override
+  String get telegram => 'Telegram';
+
+  @override
+  String get telegram_subtitle => 'Join the community on Telegram';
+
+  @override
+  String get matrix => 'Matrix';
+
+  @override
+  String get matrix_subtitle => 'Join the community on Matrix';
+
+  @override
+  String get report_an_issue => 'Report an issue';
+
+  @override
+  String get report_an_issue_subtitle => 'Found a bug? Let us know!';
+
+  @override
+  String get donate => 'Donate';
+
+  @override
+  String get donate_subtitle => 'Support continued development of Florid';
+
+  @override
+  String get share_florid => 'Share Florid';
+
+  @override
+  String get share_florid_subtitle =>
+      'Let your nerdy friends know about Florid!';
+
+  @override
+  String get share_florid_title => 'Check out Florid!';
+
+  @override
+  String get share_florid_message =>
+      'A modern F-Droid client! https://github.com/Nandanrmenon/florid';
+
+  @override
+  String get select_language => 'Select Language';
+
+  @override
+  String language_changed_to(Object language) {
+    return 'Language changed to $language.';
+  }
+
+  @override
+  String get export_favourites => 'Export favourites';
+
+  @override
+  String get no_favourites_to_export => 'No favourites to export';
+
+  @override
+  String get unable_to_access_downloads => 'Unable to access Downloads folder';
+
+  @override
+  String saved_to_downloads(Object path) {
+    return 'Saved to Downloads: $path';
+  }
+
+  @override
+  String get no_favourites_to_import => 'No favourites found to import';
+
+  @override
+  String favourites_import_found(int count, Object fileName) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Found $count $_temp0 in $fileName.';
+  }
+
+  @override
+  String favourites_imported(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Imported $count $_temp0';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1,0 +1,885 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Japanese (`ja`).
+class AppLocalizationsJa extends AppLocalizations {
+  AppLocalizationsJa([String locale = 'ja']) : super(locale);
+
+  @override
+  String get app_name => 'Florid';
+
+  @override
+  String get welcome => 'Florid へようこそ';
+
+  @override
+  String get search => '検索';
+
+  @override
+  String get settings => '設定';
+
+  @override
+  String get home => 'ホーム';
+
+  @override
+  String get categories => 'カテゴリ';
+
+  @override
+  String get updates => '更新';
+
+  @override
+  String get installed => 'インストール済み';
+
+  @override
+  String get download => 'ダウンロード';
+
+  @override
+  String get install => 'インストール';
+
+  @override
+  String get uninstall => 'アンインストール';
+
+  @override
+  String get open => '開く';
+
+  @override
+  String get cancel => 'キャンセル';
+
+  @override
+  String get update_available => '更新あり';
+
+  @override
+  String get downloading => 'ダウンロード中...';
+
+  @override
+  String get install_permission_required => 'インストール権限が必要です';
+
+  @override
+  String get storage_permission_required => 'ストレージ権限が必要です';
+
+  @override
+  String get cancel_download => 'ダウンロードをキャンセル';
+
+  @override
+  String get version => 'バージョン';
+
+  @override
+  String get size => 'サイズ';
+
+  @override
+  String get description => '説明';
+
+  @override
+  String get permissions => '権限';
+
+  @override
+  String get screenshots => 'スクリーンショット';
+
+  @override
+  String get no_version_available => '利用可能なバージョンがありません';
+
+  @override
+  String get app_information => 'アプリ情報';
+
+  @override
+  String get package_name => 'パッケージ名';
+
+  @override
+  String get license => 'ライセンス';
+
+  @override
+  String get added => '追加日';
+
+  @override
+  String get last_updated => '最終更新';
+
+  @override
+  String get version_information => 'バージョン情報';
+
+  @override
+  String get version_name => 'バージョン名';
+
+  @override
+  String get version_code => 'バージョンコード';
+
+  @override
+  String get min_sdk => '最小 SDK';
+
+  @override
+  String get target_sdk => 'ターゲット SDK';
+
+  @override
+  String get all_versions => 'すべてのバージョン';
+
+  @override
+  String get latest => '最新';
+
+  @override
+  String get released => 'リリース日';
+
+  @override
+  String get loading => '読み込み中...';
+
+  @override
+  String get error => 'エラー';
+
+  @override
+  String get retry => '再試行';
+
+  @override
+  String get share => '共有';
+
+  @override
+  String get website => 'ウェブサイト';
+
+  @override
+  String get source_code => 'ソースコード';
+
+  @override
+  String get issue_tracker => '課題トラッカー';
+
+  @override
+  String get whats_new => '新機能';
+
+  @override
+  String get show_more => 'もっと見る';
+
+  @override
+  String get show_less => '閉じる';
+
+  @override
+  String get downloads_stats => 'ダウンロード統計';
+
+  @override
+  String get last_day => '過去 1 日';
+
+  @override
+  String get last_30_days => '過去 30 日';
+
+  @override
+  String get last_365_days => '過去 365 日';
+
+  @override
+  String get not_available => '利用不可';
+
+  @override
+  String get download_failed => 'ダウンロードに失敗しました';
+
+  @override
+  String get installation_failed => 'インストールに失敗しました';
+
+  @override
+  String get uninstall_failed => 'アンインストールに失敗しました';
+
+  @override
+  String get open_failed => '開けませんでした';
+
+  @override
+  String get device => 'デバイス';
+
+  @override
+  String get recently_updated => '最近の更新';
+
+  @override
+  String get refresh => '更新';
+
+  @override
+  String get about => 'このアプリについて';
+
+  @override
+  String get refreshing_data => 'データを更新中...';
+
+  @override
+  String get data_refreshed => 'データを更新しました';
+
+  @override
+  String get refresh_failed => '更新に失敗しました';
+
+  @override
+  String get loading_latest_apps => '最新アプリを読み込み中...';
+
+  @override
+  String get latest_apps => '最新アプリ';
+
+  @override
+  String get no_apps_found => 'アプリが見つかりません';
+
+  @override
+  String get searching => '検索中...';
+
+  @override
+  String get setup_failed => 'セットアップに失敗しました';
+
+  @override
+  String get back => '戻る';
+
+  @override
+  String get allow => '許可';
+
+  @override
+  String get manage_repositories => 'リポジトリを管理';
+
+  @override
+  String get enable_disable => '有効/無効';
+
+  @override
+  String get edit => '編集';
+
+  @override
+  String get delete => '削除';
+
+  @override
+  String get delete_repository => 'リポジトリを削除';
+
+  @override
+  String delete_repository_confirm(Object name, Object repository) {
+    return '「$name」を削除してもよろしいですか？';
+  }
+
+  @override
+  String get updating_repository => 'リポジトリを更新中';
+
+  @override
+  String get touch_grass_message => '外の空気を吸うのにぴったりの時間です！';
+
+  @override
+  String get add_repository => 'リポジトリを追加';
+
+  @override
+  String get add => '追加';
+
+  @override
+  String get save => '保存';
+
+  @override
+  String get enter_repository_name => 'リポジトリ名を入力してください';
+
+  @override
+  String get enter_repository_url => 'リポジトリ URL を入力してください';
+
+  @override
+  String get edit_repository => 'リポジトリを編集';
+
+  @override
+  String get loading_apps => 'アプリを読み込み中...';
+
+  @override
+  String no_apps_in_category(Object category) {
+    return '$category にアプリが見つかりません';
+  }
+
+  @override
+  String get loading_categories => 'カテゴリを読み込み中...';
+
+  @override
+  String get no_categories_found => 'カテゴリが見つかりません';
+
+  @override
+  String get on_device => 'デバイス上';
+
+  @override
+  String get favourites => 'お気に入り';
+
+  @override
+  String get loading_repository => 'リポジトリを読み込み中…';
+
+  @override
+  String get unable_to_load_repository => 'リポジトリを読み込めません';
+
+  @override
+  String get repository_loading_error_descrption => '接続またはリポジトリ設定を確認して、もう一度お試しください。';
+
+  @override
+  String get appUpdateAvailable => '更新あり';
+
+  @override
+  String get releaseNotes => 'リリースノート';
+
+  @override
+  String get dismiss => '閉じる';
+
+  @override
+  String get viewOnGithub => 'GitHub で表示';
+
+  @override
+  String get update => '更新';
+
+  @override
+  String get installing => 'インストール中...';
+
+  @override
+  String get downloadFailed => 'APK のダウンロードに失敗しました';
+
+  @override
+  String get remove_from_favourites => 'お気に入りから削除';
+
+  @override
+  String get add_to_favourites => 'お気に入りに追加';
+
+  @override
+  String get view_details => '詳細を表示';
+
+  @override
+  String installation_started(Object appName) {
+    return '$appName のインストールを開始しました！';
+  }
+
+  @override
+  String installation_failed_with_error(Object error) {
+    return 'インストールに失敗しました: $error';
+  }
+
+  @override
+  String download_started(Object appName) {
+    return '$appName のダウンロードを開始しました！';
+  }
+
+  @override
+  String download_failed_with_error(Object error) {
+    return 'ダウンロードに失敗しました: $error';
+  }
+
+  @override
+  String get start_setup => 'セットアップを開始';
+
+  @override
+  String get continue_text => '続ける';
+
+  @override
+  String get loading_changelog => '変更履歴を読み込み中...';
+
+  @override
+  String get appearance => '外観';
+
+  @override
+  String get theme_mode => 'テーマモード';
+
+  @override
+  String get follow_system_theme => 'システム設定に従う';
+
+  @override
+  String get light_theme => 'ライトテーマ';
+
+  @override
+  String get dark_theme => 'ダークテーマ';
+
+  @override
+  String get dynamic_color => 'ダイナミックカラー';
+
+  @override
+  String get material_you_dynamic => 'Material You Dynamic';
+
+  @override
+  String get use_system_colors_supported_android => '対応する Android デバイスでシステムカラーを使用';
+
+  @override
+  String get theme_style => 'テーマスタイル';
+
+  @override
+  String get material_style => 'Material スタイル';
+
+  @override
+  String get dark_knight => 'Dark Knight';
+
+  @override
+  String get dark_knight_subtitle => 'ダークで高コントラストな Florid 風テーマ';
+
+  @override
+  String get florid_style => 'Florid スタイル';
+
+  @override
+  String get beta => 'ベータ';
+
+  @override
+  String get other => 'その他';
+
+  @override
+  String get show_whats_new => '新機能を表示';
+
+  @override
+  String get show_monthly_top_apps => '月間トップアプリを表示';
+
+  @override
+  String get feedback_on_florid_theme => 'Florid テーマへのフィードバック';
+
+  @override
+  String get help_improve_florid_theme_feedback => 'フィードバックで Florid テーマの改善にご協力ください';
+
+  @override
+  String get system_installer => 'システムインストーラー';
+
+  @override
+  String get shizuku => 'Shizuku';
+
+  @override
+  String get installation_method => 'インストール方法';
+
+  @override
+  String get requires_shizuku_running => 'Shizuku の起動が必要です';
+
+  @override
+  String get uses_standard_system_installer => '標準のシステムインストーラーを使用します';
+
+  @override
+  String get open_shizuku => 'Shizuku を開く';
+
+  @override
+  String get use_system_installer => 'システムインストーラーを使用';
+
+  @override
+  String get close => '閉じる';
+
+  @override
+  String get wifi_only => 'Wi-Fi のみ';
+
+  @override
+  String get wifi_and_charging => 'Wi-Fi + 充電中';
+
+  @override
+  String get mobile_data_or_wifi => 'モバイルデータまたは Wi-Fi';
+
+  @override
+  String get every_1_hour => '1 時間ごと';
+
+  @override
+  String get every_2_hours => '2 時間ごと';
+
+  @override
+  String get every_3_hours => '3 時間ごと';
+
+  @override
+  String get every_6_hours => '6 時間ごと';
+
+  @override
+  String get every_12_hours => '12 時間ごと';
+
+  @override
+  String get daily => '毎日';
+
+  @override
+  String every_hours(int hours) {
+    return '${hours} 時間ごと';
+  }
+
+  @override
+  String get update_network => '更新時のネットワーク';
+
+  @override
+  String get update_interval => '更新間隔';
+
+  @override
+  String get app_management => 'アプリ管理';
+
+  @override
+  String get alpha => 'アルファ';
+
+  @override
+  String get privacy => 'プライバシー';
+
+  @override
+  String get opt_out_of_telemetry => 'テレメトリをオプトアウト';
+
+  @override
+  String get opt_out_of_telemetry_subtitle => 'アクティブユーザー数（匿名）の把握に役立ちます';
+
+  @override
+  String get downloads_and_storage => 'ダウンロードとストレージ';
+
+  @override
+  String get auto_install_after_download => 'ダウンロード後に自動インストール';
+
+  @override
+  String get auto_install_after_download_subtitle => 'ダウンロード完了後に APK を自動的にインストール';
+
+  @override
+  String get delete_apk_after_install => 'インストール後に APK を削除';
+
+  @override
+  String get delete_apk_after_install_subtitle => 'インストール成功後にインストーラーファイルを削除';
+
+  @override
+  String get background_updates => 'バックグラウンド更新';
+
+  @override
+  String get check_updates_in_background => 'バックグラウンドで更新を確認';
+
+  @override
+  String get notify_when_updates_available => '更新があるときに通知';
+
+  @override
+  String get reliability => '信頼性';
+
+  @override
+  String get disable_battery_optimization => 'バッテリー最適化を無効化';
+
+  @override
+  String get allow_background_checks_reliably => 'バックグラウンドチェックを確実に実行';
+
+  @override
+  String get run_debug_check_10s => '10 秒後にデバッグチェックを実行';
+
+  @override
+  String get run_debug_check_10s_subtitle => 'テスト通知を表示し、10 秒後に実行します';
+
+  @override
+  String get debug_check_scheduled => 'デバッグチェックをスケジュールしました';
+
+  @override
+  String get debug_update_check_runs_10s => 'デバッグ更新チェックは 10 秒後に実行されます';
+
+  @override
+  String get no_recently_updated_apps => '最近更新されたアプリはありません';
+
+  @override
+  String get no_new_apps => '新しいアプリはありません';
+
+  @override
+  String get monthly_top_apps => '月間トップアプリ';
+
+  @override
+  String get from_izzyondroid => 'IzzyOnDroid より';
+
+  @override
+  String get sync_required => '同期が必要です';
+
+  @override
+  String get izzyondroid_sync_required_message => 'トップアプリを表示するには IzzyOnDroid リポジトリの同期が必要です。';
+
+  @override
+  String get go_to_settings => '設定へ';
+
+  @override
+  String get keep_android_open => 'Android をオープンに';
+
+  @override
+  String get keep_android_open_message =>
+      '2026/2027 年以降、Google は Play ストア以外からインストールしたアプリを含め、認証済みデバイス上のすべての Android アプリに開発者認証を義務付けます。';
+
+  @override
+  String get ignore => '無視';
+
+  @override
+  String get learn_more => '詳細を見る';
+
+  @override
+  String get search_fdroid_apps => 'F-Droid アプリを検索...';
+
+  @override
+  String get filters => 'フィルター';
+
+  @override
+  String get search_apps => 'アプリを検索';
+
+  @override
+  String get search_failed => '検索に失敗しました';
+
+  @override
+  String get unknown_error_occurred => '不明なエラーが発生しました';
+
+  @override
+  String get try_different_keywords => '別のキーワードを試すか、スペルを確認してください';
+
+  @override
+  String get popular_searches => '人気の検索:';
+
+  @override
+  String get clear_all => 'すべてクリア';
+
+  @override
+  String get sort_by => '並べ替え';
+
+  @override
+  String get relevance => '関連度';
+
+  @override
+  String get name_az => '名前 (A-Z)';
+
+  @override
+  String get name_za => '名前 (Z-A)';
+
+  @override
+  String get recently_added => '最近追加';
+
+  @override
+  String get no_categories_available => '利用可能なカテゴリがありません';
+
+  @override
+  String get repositories => 'リポジトリ';
+
+  @override
+  String get apply_filters => 'フィルターを適用';
+
+  @override
+  String search_results_for_query(int count, Object query) {
+    return '「$query」の検索結果 ${count} 件';
+  }
+
+  @override
+  String get loading_top_apps => 'トップアプリを読み込み中...';
+
+  @override
+  String get failed_to_load_apps => 'アプリの読み込みに失敗しました';
+
+  @override
+  String get try_again => '再試行';
+
+  @override
+  String get no_apps_from_izzyondroid => 'IzzyOnDroid からのアプリはありません';
+
+  @override
+  String get no_favourites_yet => 'お気に入りはまだありません';
+
+  @override
+  String get tap_star_to_save => 'アプリの星をタップしてここに保存';
+
+  @override
+  String update_failed_with_error(Object error) {
+    return '更新に失敗しました: $error';
+  }
+
+  @override
+  String get user => 'ユーザー';
+
+  @override
+  String auto_install_failed_with_error(Object error) {
+    return '自動インストールに失敗しました: $error';
+  }
+
+  @override
+  String installing_app(Object appName) {
+    return '$appName をインストール中...';
+  }
+
+  @override
+  String get install_from_repository => 'リポジトリからインストール';
+
+  @override
+  String get download_from_repository => 'リポジトリからダウンロード';
+
+  @override
+  String choose_repository_for_action(Object action) {
+    return 'このアプリを$actionするリポジトリを選択できます。';
+  }
+
+  @override
+  String get unknown => '不明';
+
+  @override
+  String previously_installed_from(Object repositoryName) {
+    return '以前のインストール元: $repositoryName';
+  }
+
+  @override
+  String get previously_installed_from_here => '以前ここからインストール済み';
+
+  @override
+  String get default_repository => 'デフォルト';
+
+  @override
+  String by_author(Object author) {
+    return '作者: $author';
+  }
+
+  @override
+  String check_out_on_fdroid(Object appName, Object packageName) {
+    return 'F-Droid で $appName をチェック: https://f-droid.org/packages/$packageName/';
+  }
+
+  @override
+  String get rebuild_repositories => 'リポジトリを再構築';
+
+  @override
+  String get preset => 'プリセット';
+
+  @override
+  String get your_repositories => 'あなたのリポジトリ';
+
+  @override
+  String get no_custom_repositories => 'カスタムリポジトリは追加されていません';
+
+  @override
+  String get add_custom_repository_to_start => 'カスタム F-Droid リポジトリを追加して始めましょう';
+
+  @override
+  String get scan => 'スキャン';
+
+  @override
+  String get point_camera_qr => 'カメラを QR コードに向けてください';
+
+  @override
+  String get tap_keyboard_enter_url => 'キーボードをタップして URL を手動入力';
+
+  @override
+  String get loading_repository_configuration => 'リポジトリ設定を読み込み中...';
+
+  @override
+  String get adding_selected_repositories => '選択したリポジトリを追加中...';
+
+  @override
+  String get fetching_fdroid_repository_index => 'F-Droid リポジトリインデックスを取得中...';
+
+  @override
+  String get importing_apps_to_database => 'アプリをデータベースにインポート中...';
+
+  @override
+  String importing_apps_to_database_seconds(int seconds) {
+    return 'アプリをデータベースにインポート中... (${seconds}秒)';
+  }
+
+  @override
+  String get loading_custom_repositories => 'カスタムリポジトリを読み込み中...';
+
+  @override
+  String get setup_complete => 'セットアップ完了！';
+
+  @override
+  String get welcome_to => 'ようこそ';
+
+  @override
+  String get onboarding_intro_subtitle => 'オープンソース Android アプリを簡単に閲覧・検索・ダウンロードできるモダンな F-Droid クライアントです。';
+
+  @override
+  String get curated_open_source_apps => '厳選されたオープンソースアプリ';
+
+  @override
+  String get safe_downloads => '安全なダウンロード';
+
+  @override
+  String get updates_and_notifications => '更新と通知';
+
+  @override
+  String get add_extra_repositories => '追加リポジトリを登録';
+
+  @override
+  String get repos_step_description =>
+      'Florid には公式 F-Droid リポジトリが同梱されています。信頼できるコミュニティリポジトリを追加して、より多くのアプリを入手できます。';
+
+  @override
+  String get available_repositories => '利用可能なリポジトリ';
+
+  @override
+  String get manage_repositories_anytime => '設定からいつでもリポジトリを追加・削除できます。';
+
+  @override
+  String get request_permissions => '権限のリクエスト';
+
+  @override
+  String get permissions_step_description => 'Florid は最高の体験を提供するためにいくつかの権限が必要です。';
+
+  @override
+  String get notifications => '通知';
+
+  @override
+  String get get_notified_updates => 'アプリが更新されたときに通知を受け取る';
+
+  @override
+  String get app_installation => 'アプリのインストール';
+
+  @override
+  String get allow_florid_install_apps => 'Florid がダウンロードしたアプリをインストールできるようにする';
+
+  @override
+  String get enable_permissions_anytime => 'これらの権限は設定からいつでも有効にできます。';
+
+  @override
+  String get setting_up_florid => 'Florid をセットアップ中';
+
+  @override
+  String get no_antifeature_listed => 'アンチ機能は記載されていません';
+
+  @override
+  String get open_link => 'リンクを開く';
+
+  @override
+  String get loading_recently_updated_apps => '最近更新されたアプリを読み込み中...';
+
+  @override
+  String get checking_for_updates => '更新を確認中';
+
+  @override
+  String get import_favourites => 'お気に入りをインポート';
+
+  @override
+  String get merge => 'マージ';
+
+  @override
+  String get update_all => 'すべて更新';
+
+  @override
+  String get apps => 'アプリ';
+
+  @override
+  String get troubleshooting => 'トラブルシューティング';
+
+  @override
+  String get replace => '置き換え';
+
+  @override
+  String get your_name => 'お名前';
+
+  @override
+  String get enter_your_name => 'お名前を入力';
+
+  @override
+  String get top_apps => 'トップアプリ';
+
+  @override
+  String get games => 'ゲーム';
+
+  @override
+  String get auth_all_apps => 'すべてのアプリ';
+
+  @override
+  String get auth_all_apps_desc => 'すべてのインストールに認証を要求';
+
+  @override
+  String get auth_all_apps_w_anti_feat => 'アンチ機能のあるアプリ';
+
+  @override
+  String get auth_all_apps_w_anti_feat_desc => 'アンチ機能のあるアプリのインストール時のみ認証を要求します。';
+
+  @override
+  String get support_the_developer => '開発者を支援';
+
+  @override
+  String available_on_repository(Object repositoryName) {
+    return '利用可能: $repositoryName';
+  }
+
+  @override
+  String also_available_from_repositories(Object repositoryNames) {
+    return '他のリポジトリでも利用可能: $repositoryNames';
+  }
+
+  @override
+  String get onboarding_setup_type => 'セットアップタイプ';
+
+  @override
+  String get onboarding_setup_type_desc => 'Florid のセットアップ方法を選択';
+
+  @override
+  String get onboarding_setup_basic => '基本セットアップ';
+
+  @override
+  String get onboarding_setup_basic_desc => '推奨リポジトリでクイックスタート';
+
+  @override
+  String get onboarding_setup_advanced => '詳細セットアップ';
+
+  @override
+  String get onboarding_setup_advanced_desc => 'リポジトリと設定をカスタマイズ';
+
+  @override
+  String get help_us_improve_florid => 'Florid の改善にご協力ください';
+
+  @override
+  String section_app_count(Object appCount) {
+    return '$appCount 件のアプリ';
+  }
+
+  @override
+  String get ignore_future_updates => '今後の更新を無視';
+
+}

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -289,7 +289,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get unable_to_load_repository => 'リポジトリを読み込めません';
 
   @override
-  String get repository_loading_error_descrption => '接続またはリポジトリ設定を確認して、もう一度お試しください。';
+  String get repository_loading_error_descrption =>
+      '接続またはリポジトリ設定を確認して、もう一度お試しください。';
 
   @override
   String get appUpdateAvailable => '更新あり';
@@ -372,7 +373,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get material_you_dynamic => 'Material You Dynamic';
 
   @override
-  String get use_system_colors_supported_android => '対応する Android デバイスでシステムカラーを使用';
+  String get use_system_colors_supported_android =>
+      '対応する Android デバイスでシステムカラーを使用';
 
   @override
   String get theme_style => 'テーマスタイル';
@@ -405,7 +407,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get feedback_on_florid_theme => 'Florid テーマへのフィードバック';
 
   @override
-  String get help_improve_florid_theme_feedback => 'フィードバックで Florid テーマの改善にご協力ください';
+  String get help_improve_florid_theme_feedback =>
+      'フィードバックで Florid テーマの改善にご協力ください';
 
   @override
   String get system_installer => 'システムインストーラー';
@@ -460,7 +463,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String every_hours(int hours) {
-    return '${hours} 時間ごと';
+    return '$hours 時間ごと';
   }
 
   @override
@@ -491,7 +494,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get auto_install_after_download => 'ダウンロード後に自動インストール';
 
   @override
-  String get auto_install_after_download_subtitle => 'ダウンロード完了後に APK を自動的にインストール';
+  String get auto_install_after_download_subtitle =>
+      'ダウンロード完了後に APK を自動的にインストール';
 
   @override
   String get delete_apk_after_install => 'インストール後に APK を削除';
@@ -545,7 +549,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get sync_required => '同期が必要です';
 
   @override
-  String get izzyondroid_sync_required_message => 'トップアプリを表示するには IzzyOnDroid リポジトリの同期が必要です。';
+  String get izzyondroid_sync_required_message =>
+      'トップアプリを表示するには IzzyOnDroid リポジトリの同期が必要です。';
 
   @override
   String get go_to_settings => '設定へ';
@@ -613,7 +618,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String search_results_for_query(int count, Object query) {
-    return '「$query」の検索結果 ${count} 件';
+    return '「$query」の検索結果 $count 件';
   }
 
   @override
@@ -725,7 +730,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String importing_apps_to_database_seconds(int seconds) {
-    return 'アプリをデータベースにインポート中... (${seconds}秒)';
+    return 'アプリをデータベースにインポート中... ($seconds秒)';
   }
 
   @override
@@ -738,7 +743,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get welcome_to => 'ようこそ';
 
   @override
-  String get onboarding_intro_subtitle => 'オープンソース Android アプリを簡単に閲覧・検索・ダウンロードできるモダンな F-Droid クライアントです。';
+  String get onboarding_intro_subtitle =>
+      'オープンソース Android アプリを簡単に閲覧・検索・ダウンロードできるモダンな F-Droid クライアントです。';
 
   @override
   String get curated_open_source_apps => '厳選されたオープンソースアプリ';
@@ -766,7 +772,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get request_permissions => '権限のリクエスト';
 
   @override
-  String get permissions_step_description => 'Florid は最高の体験を提供するためにいくつかの権限が必要です。';
+  String get permissions_step_description =>
+      'Florid は最高の体験を提供するためにいくつかの権限が必要です。';
 
   @override
   String get notifications => '通知';
@@ -882,4 +889,114 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get ignore_future_updates => '今後の更新を無視';
 
+  @override
+  String get general_settings => '一般設定';
+
+  @override
+  String get view_favourite_apps_subtitle => 'お気に入りアプリを表示';
+
+  @override
+  String get appearance_subtitle => 'テーマモードとスタイル';
+
+  @override
+  String get parental_control => 'ペアレンタルコントロール';
+
+  @override
+  String get parental_control_subtitle => 'アンチ機能アプリの非表示とインストール保護';
+
+  @override
+  String get app_content_language => 'アプリ表示言語';
+
+  @override
+  String get repositories_and_management => 'リポジトリと管理';
+
+  @override
+  String get manage_repositories_subtitle => 'F-Droid リポジトリの追加・削除';
+
+  @override
+  String get app_management_subtitle => 'インストールと更新に関する設定';
+
+  @override
+  String get miscellaneous => 'その他';
+
+  @override
+  String get troubleshooting_subtitle => 'ストレージ、キャッシュ、ダウンロード';
+
+  @override
+  String get florid_tagline => 'モダンな F-Droid クライアント。';
+
+  @override
+  String get source_code_subtitle => 'GitHub で Florid のソースコードを表示';
+
+  @override
+  String get telegram => 'Telegram';
+
+  @override
+  String get telegram_subtitle => 'Telegram コミュニティに参加';
+
+  @override
+  String get matrix => 'Matrix';
+
+  @override
+  String get matrix_subtitle => 'Matrix コミュニティに参加';
+
+  @override
+  String get report_an_issue => '問題を報告';
+
+  @override
+  String get report_an_issue_subtitle => 'バグを見つけましたか？お知らせください！';
+
+  @override
+  String get donate => '寄付';
+
+  @override
+  String get donate_subtitle => 'Florid の開発を支援';
+
+  @override
+  String get share_florid => 'Florid を共有';
+
+  @override
+  String get share_florid_subtitle => '詳しい友達に Florid を教えましょう！';
+
+  @override
+  String get share_florid_title => 'Florid をチェック！';
+
+  @override
+  String get share_florid_message =>
+      'モダンな F-Droid クライアント！ https://github.com/Nandanrmenon/florid';
+
+  @override
+  String get select_language => '言語を選択';
+
+  @override
+  String language_changed_to(Object language) {
+    return '言語を $language に変更しました。';
+  }
+
+  @override
+  String get export_favourites => 'お気に入りをエクスポート';
+
+  @override
+  String get no_favourites_to_export => 'エクスポートするお気に入りがありません';
+
+  @override
+  String get unable_to_access_downloads => 'ダウンロードフォルダにアクセスできません';
+
+  @override
+  String saved_to_downloads(Object path) {
+    return 'ダウンロードに保存しました: $path';
+  }
+
+  @override
+  String get no_favourites_to_import => 'インポートするお気に入りが見つかりません';
+
+  @override
+  String favourites_import_found(int count, Object fileName) {
+    return '$fileName に $count 件のお気に入りが見つかりました。';
+  }
+
+  @override
+  String favourites_imported(int count) {
+    return '$count 件のお気に入りをインポートしました';
+  }
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -912,4 +912,131 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get ignore_future_updates => 'Ignore Future Updates';
+
+  @override
+  String get general_settings => 'General Settings';
+
+  @override
+  String get view_favourite_apps_subtitle => 'View your favourite apps';
+
+  @override
+  String get appearance_subtitle => 'Theme mode and style';
+
+  @override
+  String get parental_control => 'Parental Control';
+
+  @override
+  String get parental_control_subtitle =>
+      'Hide anti-feature apps and protect installs';
+
+  @override
+  String get app_content_language => 'App content language';
+
+  @override
+  String get repositories_and_management => 'Repositories & Management';
+
+  @override
+  String get manage_repositories_subtitle =>
+      'Add or remove F-Droid repositories';
+
+  @override
+  String get app_management_subtitle =>
+      'Manage settings regarding installs and updates';
+
+  @override
+  String get miscellaneous => 'Miscellaneous';
+
+  @override
+  String get troubleshooting_subtitle => 'Storage, cache, and downloads';
+
+  @override
+  String get florid_tagline => 'A modern F-Droid client.';
+
+  @override
+  String get source_code_subtitle => 'View the Florid source code on GitHub';
+
+  @override
+  String get telegram => 'Telegram';
+
+  @override
+  String get telegram_subtitle => 'Join the community on Telegram';
+
+  @override
+  String get matrix => 'Matrix';
+
+  @override
+  String get matrix_subtitle => 'Join the community on Matrix';
+
+  @override
+  String get report_an_issue => 'Report an issue';
+
+  @override
+  String get report_an_issue_subtitle => 'Found a bug? Let us know!';
+
+  @override
+  String get donate => 'Donate';
+
+  @override
+  String get donate_subtitle => 'Support continued development of Florid';
+
+  @override
+  String get share_florid => 'Share Florid';
+
+  @override
+  String get share_florid_subtitle =>
+      'Let your nerdy friends know about Florid!';
+
+  @override
+  String get share_florid_title => 'Check out Florid!';
+
+  @override
+  String get share_florid_message =>
+      'A modern F-Droid client! https://github.com/Nandanrmenon/florid';
+
+  @override
+  String get select_language => 'Select Language';
+
+  @override
+  String language_changed_to(Object language) {
+    return 'Language changed to $language.';
+  }
+
+  @override
+  String get export_favourites => 'Export favourites';
+
+  @override
+  String get no_favourites_to_export => 'No favourites to export';
+
+  @override
+  String get unable_to_access_downloads => 'Unable to access Downloads folder';
+
+  @override
+  String saved_to_downloads(Object path) {
+    return 'Saved to Downloads: $path';
+  }
+
+  @override
+  String get no_favourites_to_import => 'No favourites found to import';
+
+  @override
+  String favourites_import_found(int count, Object fileName) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Found $count $_temp0 in $fileName.';
+  }
+
+  @override
+  String favourites_imported(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Imported $count $_temp0';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -889,6 +889,133 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get ignore_future_updates => 'Ignore Future Updates';
+
+  @override
+  String get general_settings => 'General Settings';
+
+  @override
+  String get view_favourite_apps_subtitle => 'View your favourite apps';
+
+  @override
+  String get appearance_subtitle => 'Theme mode and style';
+
+  @override
+  String get parental_control => 'Parental Control';
+
+  @override
+  String get parental_control_subtitle =>
+      'Hide anti-feature apps and protect installs';
+
+  @override
+  String get app_content_language => 'App content language';
+
+  @override
+  String get repositories_and_management => 'Repositories & Management';
+
+  @override
+  String get manage_repositories_subtitle =>
+      'Add or remove F-Droid repositories';
+
+  @override
+  String get app_management_subtitle =>
+      'Manage settings regarding installs and updates';
+
+  @override
+  String get miscellaneous => 'Miscellaneous';
+
+  @override
+  String get troubleshooting_subtitle => 'Storage, cache, and downloads';
+
+  @override
+  String get florid_tagline => 'A modern F-Droid client.';
+
+  @override
+  String get source_code_subtitle => 'View the Florid source code on GitHub';
+
+  @override
+  String get telegram => 'Telegram';
+
+  @override
+  String get telegram_subtitle => 'Join the community on Telegram';
+
+  @override
+  String get matrix => 'Matrix';
+
+  @override
+  String get matrix_subtitle => 'Join the community on Matrix';
+
+  @override
+  String get report_an_issue => 'Report an issue';
+
+  @override
+  String get report_an_issue_subtitle => 'Found a bug? Let us know!';
+
+  @override
+  String get donate => 'Donate';
+
+  @override
+  String get donate_subtitle => 'Support continued development of Florid';
+
+  @override
+  String get share_florid => 'Share Florid';
+
+  @override
+  String get share_florid_subtitle =>
+      'Let your nerdy friends know about Florid!';
+
+  @override
+  String get share_florid_title => 'Check out Florid!';
+
+  @override
+  String get share_florid_message =>
+      'A modern F-Droid client! https://github.com/Nandanrmenon/florid';
+
+  @override
+  String get select_language => 'Select Language';
+
+  @override
+  String language_changed_to(Object language) {
+    return 'Language changed to $language.';
+  }
+
+  @override
+  String get export_favourites => 'Export favourites';
+
+  @override
+  String get no_favourites_to_export => 'No favourites to export';
+
+  @override
+  String get unable_to_access_downloads => 'Unable to access Downloads folder';
+
+  @override
+  String saved_to_downloads(Object path) {
+    return 'Saved to Downloads: $path';
+  }
+
+  @override
+  String get no_favourites_to_import => 'No favourites found to import';
+
+  @override
+  String favourites_import_found(int count, Object fileName) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Found $count $_temp0 in $fileName.';
+  }
+
+  @override
+  String favourites_imported(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'favourites',
+      one: 'favourite',
+    );
+    return 'Imported $count $_temp0';
+  }
 }
 
 /// The translations for Chinese, as used in China (`zh_CN`).

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:florid/screens/florid_app.dart';
 import 'package:florid/themes/app_themes.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
 import 'providers/app_provider.dart';
@@ -128,6 +129,22 @@ class MainApp extends StatelessWidget {
                 navigatorKey: appNavigatorKey,
                 localizationsDelegates: AppLocalizations.localizationsDelegates,
                 supportedLocales: AppLocalizations.supportedLocales,
+                locale: settings.uiLocale,
+                localeResolutionCallback: (deviceLocale, supportedLocales) {
+                  final forced = settings.uiLocale;
+                  if (forced != null) {
+                    return basicLocaleListResolution(
+                          [forced],
+                          supportedLocales,
+                        ) ??
+                        const Locale('en');
+                  }
+                  return basicLocaleListResolution(
+                        [deviceLocale ?? const Locale('en')],
+                        supportedLocales,
+                      ) ??
+                      const Locale('en');
+                },
                 theme: lightTheme,
                 darkTheme: darkThemeData,
                 themeMode: settings.themeMode,

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -241,6 +241,43 @@ class SettingsProvider extends ChangeNotifier {
 
   String get effectiveLocale => resolveEffectiveLocale(_locale);
 
+  /// Maps the settings locale to a Flutter [Locale] for MaterialApp UI strings.
+  /// Returns null when following the system locale.
+  Locale? get uiLocale {
+    if (_locale == systemLocale) {
+      return null;
+    }
+    return mapSettingsLocaleToUi(_locale);
+  }
+
+  /// Maps a settings locale code to a supported UI [Locale].
+  static Locale mapSettingsLocaleToUi(String locale) {
+    switch (locale) {
+      case 'de-DE':
+      case 'de':
+        return const Locale('de');
+      case 'it-IT':
+      case 'it':
+        return const Locale('it');
+      case 'ja-JP':
+      case 'ja':
+        return const Locale('ja');
+      case 'zh-CN':
+      case 'zh':
+        return const Locale('zh', 'CN');
+      case 'en-US':
+      case 'en':
+        return const Locale('en');
+      case 'cs':
+      case 'cz':
+        return const Locale('cs');
+      case 'tr':
+        return const Locale('tr');
+      default:
+        return const Locale('en');
+    }
+  }
+
   static String resolveEffectiveLocale(String locale) {
     if (locale != systemLocale) {
       return locale;

--- a/lib/screens/florid_app.dart
+++ b/lib/screens/florid_app.dart
@@ -322,7 +322,7 @@ class _FloridAppState extends State<FloridApp> {
                         ? (settings.userName.length > 10
                               ? '${settings.userName.substring(0, 10)}...'
                               : settings.userName)
-                        : 'User',
+                        : localizations.user,
                   ),
                 ),
               ];
@@ -527,7 +527,7 @@ class _FloridAppState extends State<FloridApp> {
                         ? (settings.userName.length > 10
                               ? '${settings.userName.substring(0, 10)}...'
                               : settings.userName)
-                        : 'User',
+                        : localizations.user,
                   ),
                 ];
 

--- a/lib/screens/settings/user_screen.dart
+++ b/lib/screens/settings/user_screen.dart
@@ -289,6 +289,8 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
   Widget build(BuildContext context) {
     return Consumer<SettingsProvider>(
       builder: (context, settings, _) {
+        final localizations = AppLocalizations.of(context)!;
+
         return Column(
           children: <Widget>[
             const SizedBox(height: 16),
@@ -296,16 +298,16 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
             Column(
               spacing: 4,
               children: [
-                const MListHeader(
-                  title: 'General Settings',
+                MListHeader(
+                  title: localizations.general_settings,
                   icon: Symbols.mobile,
                 ),
                 MListView(
                   items: [
                     MListItemData(
                       leading: ListIcon(iconData: SolarIconsBold.heart),
-                      title: 'Favourites',
-                      subtitle: 'View your favourite apps',
+                      title: localizations.favourites,
+                      subtitle: localizations.view_favourite_apps_subtitle,
                       onTap: () {
                         Navigator.push(
                           context,
@@ -318,8 +320,8 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                     ),
                     MListItemData(
                       leading: ListIcon(iconData: SolarIconsBold.palette),
-                      title: 'Appearance',
-                      subtitle: 'Theme mode and style',
+                      title: localizations.appearance,
+                      subtitle: localizations.appearance_subtitle,
                       onTap: () {
                         Navigator.push(
                           context,
@@ -332,8 +334,8 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                     ),
                     MListItemData(
                       leading: ListIcon(iconData: SolarIconsBold.shield),
-                      title: 'Parental Control',
-                      subtitle: 'Hide anti-feature apps and protect installs',
+                      title: localizations.parental_control,
+                      subtitle: localizations.parental_control_subtitle,
                       onTap: () {
                         Navigator.push(
                           context,
@@ -346,7 +348,7 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                     ),
                     MListItemData(
                       leading: ListIcon(iconData: SolarIconsBold.globus),
-                      title: 'App content language',
+                      title: localizations.app_content_language,
                       onTap: () => _showLanguageDialog(context, settings),
                       subtitle: SettingsProvider.getLocaleDisplayName(
                         settings.locale,
@@ -361,15 +363,15 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
             Column(
               spacing: 4,
               children: [
-                const MListHeader(
-                  title: 'Repositories & Management',
+                MListHeader(
+                  title: localizations.repositories_and_management,
                   icon: Symbols.settings,
                 ),
                 MListView(
                   items: [
                     MListItemData(
                       leading: ListIcon(iconData: SolarIconsBold.cloud),
-                      title: 'Manage repositories',
+                      title: localizations.manage_repositories,
                       onTap: () {
                         Navigator.push(
                           context,
@@ -378,16 +380,15 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                           ),
                         );
                       },
-                      subtitle: 'Add or remove F-Droid repositories',
+                      subtitle: localizations.manage_repositories_subtitle,
                       suffix: const Icon(Symbols.chevron_right),
                     ),
                     MListItemData(
                       leading: ListIcon(
                         iconData: SolarIconsBold.settingsMinimalistic,
                       ),
-                      title: 'App Management',
-                      subtitle:
-                          'Manage settings regarding installs and updates',
+                      title: localizations.app_management,
+                      subtitle: localizations.app_management_subtitle,
                       onTap: () {
                         Navigator.push(
                           context,
@@ -413,13 +414,11 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                         spacing: 12.0,
                         children: [
                           Text(
-                            'Keep Android Open',
+                            localizations.keep_android_open,
                             style: Theme.of(context).textTheme.titleMedium
                                 ?.copyWith(fontWeight: FontWeight.w600),
                           ),
-                          const Text(
-                            'From 2026/2027 onward, Google will require developer verification for all Android apps on certified devices, including those installed outside of the Play Store.',
-                          ),
+                          Text(localizations.keep_android_open_message),
                           Row(
                             mainAxisAlignment: MainAxisAlignment.end,
                             children: [
@@ -455,16 +454,16 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
             Column(
               spacing: 4.0,
               children: [
-                const MListHeader(
-                  title: 'Miscellaneous',
+                MListHeader(
+                  title: localizations.miscellaneous,
                   icon: Symbols.more_horiz,
                 ),
                 MListView(
                   items: [
                     MListItemData(
                       leading: ListIcon(iconData: SolarIconsBold.sledgehammer),
-                      title: 'Troubleshooting',
-                      subtitle: 'Storage, cache, and downloads',
+                      title: localizations.troubleshooting,
+                      subtitle: localizations.troubleshooting_subtitle,
                       onTap: () {
                         Navigator.push(
                           context,
@@ -482,13 +481,15 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                     MListItemData(
                       leading: ListIcon(iconData: SolarIconsBold.infoSquare),
                       title: AppLocalizations.of(context)!.version,
-                      subtitle: _appVersion.isEmpty ? 'Loading…' : _appVersion,
+                      subtitle: _appVersion.isEmpty
+                          ? AppLocalizations.of(context)!.loading
+                          : _appVersion,
                       onTap: () {
                         showAboutDialog(
                           context: context,
                           applicationName: kAppName,
                           applicationVersion: _appVersion,
-                          children: [Text('A modern F-Droid client.')],
+                          children: [Text(localizations.florid_tagline)],
                           applicationIcon: SvgPicture.asset(
                             kAppLogoSvg,
                             key: const ValueKey('app_logo'),
@@ -503,8 +504,8 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                     ),
                     MListItemData(
                       leading: SocialListIcon(icon: Bxl.git),
-                      title: 'Source code',
-                      subtitle: 'View the Florid source code on GitHub',
+                      title: localizations.source_code,
+                      subtitle: localizations.source_code_subtitle,
                       suffix: Icon(SolarIconsOutline.squareBottomUp),
                       onTap: () async {
                         final url = Uri.parse(
@@ -517,8 +518,8 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                     ),
                     MListItemData(
                       leading: SocialListIcon(icon: Bxl.telegram),
-                      title: 'Telegram',
-                      subtitle: 'Join the community on Telegram',
+                      title: localizations.telegram,
+                      subtitle: localizations.telegram_subtitle,
                       suffix: Icon(SolarIconsOutline.squareBottomUp),
                       onTap: () async {
                         final url = Uri.parse('https://t.me/florid_app');
@@ -529,8 +530,8 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                     ),
                     MListItemData(
                       leading: SocialListIcon(icon: SimpleIcons.matrix),
-                      title: 'Matrix',
-                      subtitle: 'Join the community on Matrix',
+                      title: localizations.matrix,
+                      subtitle: localizations.matrix_subtitle,
                       suffix: Icon(SolarIconsOutline.squareBottomUp),
                       onTap: () async {
                         final url = Uri.parse(
@@ -545,8 +546,8 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                       leading: ListIcon(
                         iconData: SolarIconsBold.roundedMagnifierBug,
                       ),
-                      title: 'Report an issue',
-                      subtitle: 'Found a bug? Let us know!',
+                      title: localizations.report_an_issue,
+                      subtitle: localizations.report_an_issue_subtitle,
                       suffix: Icon(SolarIconsOutline.squareBottomUp),
                       onTap: () async {
                         final url = Uri.parse(
@@ -559,8 +560,8 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                     ),
                     MListItemData(
                       leading: ListIcon(iconData: SolarIconsBold.heartShine),
-                      title: 'Donate',
-                      subtitle: 'Support continued development of Florid',
+                      title: localizations.donate,
+                      subtitle: localizations.donate_subtitle,
                       suffix: Icon(SolarIconsOutline.squareBottomUp),
                       onTap: () async {
                         final url = Uri.parse('https://ko-fi.com/nandanrmenon');
@@ -571,14 +572,13 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                     ),
                     MListItemData(
                       leading: ListIcon(iconData: SolarIconsBold.share),
-                      title: 'Share Florid',
-                      subtitle: 'Let your nerdy friends know about Florid!',
+                      title: localizations.share_florid,
+                      subtitle: localizations.share_florid_subtitle,
                       onTap: () {
                         SharePlus.instance.share(
                           ShareParams(
-                            title: 'Check out Florid!',
-                            text:
-                                'A modern F-Droid client! https://github.com/Nandanrmenon/florid',
+                            title: localizations.share_florid_title,
+                            text: localizations.share_florid_message,
                           ),
                         );
                       },
@@ -605,10 +605,12 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
     final appProvider = parentContext.read<AppProvider>();
     final repositoriesProvider = parentContext.read<RepositoriesProvider>();
 
+    final localizations = AppLocalizations.of(parentContext)!;
+
     await showDialog(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: const Text('Select Language'),
+        title: Text(localizations.select_language),
         content: SizedBox(
           width: double.maxFinite,
           child: ListView.builder(
@@ -643,7 +645,9 @@ class _UserSettingsContentState extends State<_UserSettingsContent> {
                     messenger.showSnackBar(
                       SnackBar(
                         content: Text(
-                          'Language changed to ${SettingsProvider.getLocaleDisplayName(value)}.',
+                          localizations.language_changed_to(
+                            SettingsProvider.getLocaleDisplayName(value),
+                          ),
                         ),
                       ),
                     );
@@ -673,6 +677,7 @@ class _FavoriteAppsScreen extends StatefulWidget {
 
 class _FavoriteAppsScreenState extends State<_FavoriteAppsScreen> {
   Future<void> _exportFavorites(BuildContext context) async {
+    final localizations = AppLocalizations.of(context)!;
     final appProvider = context.read<AppProvider>();
     final favorites = appProvider.favoritePackages.toList()..sort();
 
@@ -680,7 +685,7 @@ class _FavoriteAppsScreenState extends State<_FavoriteAppsScreen> {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('No favourites to export')));
+      ).showSnackBar(SnackBar(content: Text(localizations.no_favourites_to_export)));
       return;
     }
 
@@ -698,7 +703,7 @@ class _FavoriteAppsScreenState extends State<_FavoriteAppsScreen> {
     if (downloadsDir == null) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Unable to access Downloads folder')),
+        SnackBar(content: Text(localizations.unable_to_access_downloads)),
       );
       return;
     }
@@ -709,7 +714,9 @@ class _FavoriteAppsScreenState extends State<_FavoriteAppsScreen> {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('Saved to Downloads: ${downloadsDir.path}/$fileName'),
+        content: Text(
+          localizations.saved_to_downloads('${downloadsDir.path}/$fileName'),
+        ),
       ),
     );
   }
@@ -738,6 +745,7 @@ class _FavoriteAppsScreenState extends State<_FavoriteAppsScreen> {
   }
 
   Future<void> _importFavorites(BuildContext context) async {
+    final localizations = AppLocalizations.of(context)!;
     final appProvider = context.read<AppProvider>();
     final picked = await FilePicker.pickFiles(
       type: FileType.custom,
@@ -757,7 +765,7 @@ class _FavoriteAppsScreenState extends State<_FavoriteAppsScreen> {
     if (parsed.isEmpty) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('No favourites found to import')),
+        SnackBar(content: Text(localizations.no_favourites_to_import)),
       );
       return;
     }
@@ -768,7 +776,7 @@ class _FavoriteAppsScreenState extends State<_FavoriteAppsScreen> {
         icon: const Icon(Symbols.star),
         title: Text(AppLocalizations.of(context)!.import_favourites),
         content: Text(
-          'Found ${parsed.length} favourite${parsed.length == 1 ? '' : 's'} in ${file.name}.',
+          localizations.favourites_import_found(parsed.length, file.name),
         ),
         actions: [
           TextButton(
@@ -799,9 +807,7 @@ class _FavoriteAppsScreenState extends State<_FavoriteAppsScreen> {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text(
-          'Imported ${parsed.length} favourite${parsed.length == 1 ? '' : 's'}',
-        ),
+        content: Text(localizations.favourites_imported(parsed.length)),
       ),
     );
   }
@@ -890,7 +896,7 @@ class _FavoriteAppsScreenState extends State<_FavoriteAppsScreen> {
                               spacing: 8.0,
                               children: [
                                 const Icon(Symbols.file_download),
-                                const Text('Export favourites'),
+                                Text(localizations.export_favourites),
                               ],
                             ),
                           ),


### PR DESCRIPTION
## Summary

- Add `app_ja.arb` with all UI strings translated into Japanese (including User tab / Settings screen)
- Regenerate localization code (`app_localizations_ja.dart`, update `app_localizations.dart`)
- Localize User tab: replace hardcoded English in `user_screen.dart` and navigation label in `florid_app.dart`
- Bind the settings language picker to `MaterialApp` locale so selecting 日本語 (`ja-JP`) also switches the UI to Japanese
- F-Droid app content locale (`ja-JP`) was already supported; no changes needed there

## Test plan

- [ ] Change device/system language to Japanese and verify UI strings appear in Japanese
- [ ] In Settings → App content language, select 日本語 and confirm menus/buttons (including User tab) switch to Japanese immediately
- [ ] Select a UI-unsupported locale (e.g. Español) and confirm UI falls back to English while F-Droid content uses the selected locale
- [ ] Run `flutter gen-l10n` and `flutter analyze` locally

Made with [Cursor](https://cursor.com)